### PR TITLE
Small changes to get the demo and spatial_demo to work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [lib]
 name = "geosot"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
 pyo3 = { version = "0.25.1", features = ["extension-module"] }

--- a/examples/spatial_demo.rs
+++ b/examples/spatial_demo.rs
@@ -6,7 +6,6 @@ fn main() {
 
     // 创建测试区域
     let level = 20;
-    use geosot::spatial::GeoSotRegion;
 
     // 创建矩形区域
     let region = GeoSotRegion::from_rectangle(
@@ -130,7 +129,7 @@ fn main() {
         (116.2, 39.2),
         (116.0, 39.2),
     ];
-    let polygon_region = GeoSotRegion::from_polygon(&polygon_points, 18);
+    let polygon_region = GeoSotRegion::from_polygon(polygon_points, 18);
     println!("多边形区域包含 {} 个网格", polygon_region.size());
     println!();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,6 @@ fn geosot(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(merge_by_bits, m)?)?;
     m.add_class::<spatial::GeoSotCell>()?;
     m.add_class::<spatial::GeoSotRegion>()?;
-    m.add_wrapped(wrap_pymodule!(spatial::spatial_analysis))?;
+    m.add_wrapped(wrap_pymodule!(spatial::spatial_analysis_py))?;
     Ok(())
 }

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -90,6 +90,12 @@ impl GeoSotCell {
     }
 }
 
+impl std::fmt::Display for GeoSotCell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", to_string(self.code, self.level))
+    }
+}
+
 /// GeoSOT 编码的空间区域表示
 #[pyclass]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -472,7 +478,7 @@ mod tests {
     fn test_geosot_cell_creation() {
         let cell = GeoSotCell::from_coords(116.397, 39.916, 20);
         assert_eq!(cell.level, 20);
-        println!("Cell: {}", cell.to_string());
+        println!("Cell: {}", cell);
     }
 
     #[test]

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -375,12 +375,12 @@ impl GeoSotRegion {
     }
 }
 
-#[pymodule]
-pub fn spatial_analysis(m: &Bound<'_, PyModule>) -> PyResult<()> {
+/// 空间分析函数模块
+pub mod spatial_analysis {
+    use super::*;
+
     /// 计算两个区域的 Jaccard 相似度
-    #[pyfn(m)]
-    #[pyo3(name = "jaccard_similarity")]
-    fn jaccard_similarity_py(region1: &GeoSotRegion, region2: &GeoSotRegion) -> f64 {
+    pub fn jaccard_similarity(region1: &GeoSotRegion, region2: &GeoSotRegion) -> f64 {
         if region1.level != region2.level {
             return 0.0;
         }
@@ -396,9 +396,7 @@ pub fn spatial_analysis(m: &Bound<'_, PyModule>) -> PyResult<()> {
     }
 
     /// 计算两个区域的重叠率
-    #[pyfn(m)]
-    #[pyo3(name = "overlap_ratio")]
-    fn overlap_ratio_py(region1: &GeoSotRegion, region2: &GeoSotRegion) -> f64 {
+    pub fn overlap_ratio(region1: &GeoSotRegion, region2: &GeoSotRegion) -> f64 {
         if region1.level != region2.level || region1.is_empty() {
             return 0.0;
         }
@@ -408,9 +406,7 @@ pub fn spatial_analysis(m: &Bound<'_, PyModule>) -> PyResult<()> {
     }
 
     /// 计算区域的紧密度（连通性度量）
-    #[pyfn(m)]
-    #[pyo3(name = "compactness")]
-    fn compactness_py(region: &GeoSotRegion) -> f64 {
+    pub fn compactness(region: &GeoSotRegion) -> f64 {
         if region.size() <= 1 {
             return 1.0;
         }
@@ -432,6 +428,27 @@ pub fn spatial_analysis(m: &Bound<'_, PyModule>) -> PyResult<()> {
         } else {
             adjacent_pairs as f64 / total_pairs as f64
         }
+    }
+}
+
+#[pymodule]
+pub fn spatial_analysis_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    #[pyfn(m)]
+    #[pyo3(name = "jaccard_similarity")]
+    fn jaccard_similarity_py(region1: &GeoSotRegion, region2: &GeoSotRegion) -> f64 {
+        spatial_analysis::jaccard_similarity(region1, region2)
+    }
+
+    #[pyfn(m)]
+    #[pyo3(name = "overlap_ratio")]
+    fn overlap_ratio_py(region1: &GeoSotRegion, region2: &GeoSotRegion) -> f64 {
+        spatial_analysis::overlap_ratio(region1, region2)
+    }
+
+    #[pyfn(m)]
+    #[pyo3(name = "compactness")]
+    fn compactness_py(region: &GeoSotRegion) -> f64 {
+        spatial_analysis::compactness(region)
     }
 
     Ok(())

--- a/tests/spatial_test.rs
+++ b/tests/spatial_test.rs
@@ -178,7 +178,7 @@ mod tests {
             (116.1, 39.1),
             (115.9, 39.1),
         ];
-        let polygon_region = GeoSotRegion::from_polygon(&polygon_points, level);
+        let polygon_region = GeoSotRegion::from_polygon(polygon_points, level);
         println!("多边形区域大小: {}", polygon_region.size());
         assert!(polygon_region.size() > 0);
         

--- a/tests/spatial_test.rs
+++ b/tests/spatial_test.rs
@@ -2,7 +2,7 @@
 #[cfg(test)]
 mod tests {
     use geosot::spatial::{GeoSotRegion, spatial_analysis};
-    use geosot::{get_code, to_string};
+    use geosot::get_code;
 
     #[test]
     fn test_basic_spatial_operations() {


### PR DESCRIPTION
Here is what I did to get `demo` and `spatial_demo` to work. 

  1. Cargo.toml: Added `lib` to crate-type `["cdylib"]` only builds for Python/C, Rust examples need
  `lib`.
  2. `src/spatial.rs`: Extracted `jaccard_similarity`, `overlap_ratio`, and `compactness` into a regular `pub
  mod spatial_analysis` so they're callable from Rust. The PyO3 module wrapper was renamed to
  `spatial_analysis_py` and delegates to those functions.
  3. `src/lib.rs`: Updated the PyO3 module reference from `spatial_analysis` to `spatial_analysis_py`.
  4. `examples/spatial_demo.rs`: Removed duplicate use import and fixed `from_polygon(&polygon_points,
  18)` -> `from_polygon(polygon_points, 18)` (owned `Vec`, not a reference).
  5. `tests/spatial_test.rs`: Same `from_polygon` borrow fix.
  
  Happy to discuss and change, if you think that is too much @sxhxliang .
